### PR TITLE
Add 'ignore' and 'ignore-attributes' to list of i18n valid attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 4.1.2 (unreleased)
 ------------------
 
-- TBD
+- Accept and ignore ``i18n:ignore`` and ``i18n:ignore-attributes`` attributes.
+  For compatibility with other tools (such as ``i18ndude``).
 
 4.1.1 (2015-06-05)
 ------------------

--- a/src/zope/tal/taldefs.py
+++ b/src/zope/tal/taldefs.py
@@ -61,6 +61,8 @@ KNOWN_I18N_ATTRIBUTES = frozenset([
     "attributes",
     "data",
     "name",
+    "ignore",
+    "ignore-attributes",
     ])
 
 class TALError(Exception):

--- a/src/zope/tal/tests/input/test38.html
+++ b/src/zope/tal/tests/input/test38.html
@@ -1,0 +1,8 @@
+<span xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+  <i18n:block ignore="">Test</i18n:block>
+  <a href="http://www.python.org"
+     title="Python"
+     i18n:ignore-attributes="title">
+    Python is a programming language.
+  </a>
+</span>

--- a/src/zope/tal/tests/output/test38.html
+++ b/src/zope/tal/tests/output/test38.html
@@ -1,0 +1,6 @@
+<span>
+  Test
+  <a href="http://www.python.org" title="Python">
+    Python is a programming language.
+  </a>
+</span>


### PR DESCRIPTION
i18n:ignore is used by i18ndude to ignore certain tags.

This way the report tool on i18ndude will not complain if a string is not marked as translatable.