### PR TITLE
Add Python 3.6, drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,10 @@
 [run]
 source = zope.tal
+omit =
+   src/zope/tal/tests/run.py
+   src/zope/tal/tests/markbench.py
+   src/zope/tal/timer.py
+   src/zope/tal/runtest.py
 
 [report]
 precision = 2

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.tal
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ develop-eggs/
 .coverage
 coverage.xml
 nosetests.xml
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: python
 sudo: false
-matrix:
-  include:
-    - python: 3.5
-      env: TOXENV=py35
-env:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=pypy
-    - TOXENV=pypy3
+python:
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy
+    - pypy3.5-5.8.0
 install:
-    - pip install tox
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - tox --develop
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,16 @@
-Changes
-=======
+=========
+ Changes
+=========
 
-4.2.1 (unreleased)
-------------------
+4.3.0 (unreleased)
+==================
 
-- TBD
+- Drop support for Python 3.3.
+
+- Add support for Python 3.6.
 
 4.2.0 (2016-04-12)
-------------------
+==================
 
 - Drop support for Python 2.6 and 3.2.
 
@@ -17,7 +20,7 @@ Changes
 - Add support for Python 3.5.
 
 4.1.1 (2015-06-05)
-------------------
+==================
 
 - Suppress deprecation under Python 3.4 for default ``convert_charrefs``
   argument (passed to ``HTMLParser``).  Also ensures that upcoming change
@@ -26,7 +29,7 @@ Changes
 - Add support for Python 3.2 and PyPy3.
 
 4.1.0 (2014-12-19)
-------------------
+==================
 
 .. note::
 
@@ -39,13 +42,13 @@ Changes
 
 
 4.0.0 (2014-01-13)
-------------------
+==================
 
 - Fix possible UnicodeDecodeError in warning when msgid already exists.
 
 
 4.0.0a1 (2013-02-15)
---------------------
+====================
 
 - Replace deprecated ``zope.interface.implements`` usage with equivalent
   ``zope.interface.implementer`` decorator.
@@ -59,7 +62,7 @@ Changes
 
 
 3.6.1 (2012-03-09)
-------------------
+==================
 
 - Avoid handling end tags within <script> tags in the HTML parser. This works
   around http://bugs.python.org/issue670664
@@ -67,7 +70,7 @@ Changes
 - Fix documentation link in README.txt.
 
 3.6.0 (2011-08-20)
-------------------
+==================
 
 - Update `talinterpreter.FasterStringIO` to faster list-based implementation.
 
@@ -78,21 +81,21 @@ Changes
 
 
 3.5.2 (2009-10-31)
-------------------
+==================
 
 - In ``talgettext.POEngine.translate``, print a warning if a msgid already
   exists in the domain with a different default.
 
 
 3.5.1 (2009-03-08)
-------------------
+==================
 
 - Update tests of "bad" entities for compatibility with the stricter
   HTMLParser module shipped with Python 2.6.x.
 
 
 3.5.0 (2008-06-06)
-------------------
+==================
 
 - Remove artificial addition of a trailing newline if the output doesn't end
   in one; this allows the template source to be the full specification of what
@@ -101,7 +104,7 @@ Changes
 
 
 3.4.1 (2007-11-16)
-------------------
+==================
 
 - Remove unnecessary ``dummyengine`` dependency on zope.i18n to
   simplify distribution.  The ``dummyengine.DummyTranslationDomain``
@@ -117,13 +120,13 @@ Changes
 
 
 3.4.0 (2007-10-03)
-------------------
+==================
 
 - Update package meta-data.
 
 
 3.4.0b1
--------
+=======
 
 - Update dependency on ``zope.i18n`` to a verions requiring the correct
   version of ``zope.security``, avoiding a hidden dependency issue in

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,20 @@
-``zope.tal``
-============
+==============
+ ``zope.tal``
+==============
 
 .. image:: https://img.shields.io/pypi/v/zope.tal.svg
-    :target: https://pypi.python.org/pypi/zope.tal/
-    :alt: Latest Version
+        :target: https://pypi.python.org/pypi/zope.tal/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.tal.svg
+        :target: https://pypi.org/project/zope.tal/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.tal.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.tal
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.tal/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.tal?branch=master
 
 The Zope3 Template Attribute Languate (TAL) specifies the custom namespace
 and attributes which are used by the Zope Page Templates renderer to inject

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,5 @@ cover-erase=1
 with-doctest=0
 where=src
 
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,13 @@ def alltests():
     suites = list(find_suites(options))
     return TestSuite(suites)
 
+TESTS_REQUIRE = [
+    'zope.testing',
+    'zope.testrunner',
+]
+
 setup(name='zope.tal',
-      version='4.2.1.dev0',
+      version='4.3.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Template Application Language (TAL)',
@@ -51,9 +56,9 @@ setup(name='zope.tal',
           read('README.rst')
           + '\n\n' +
           read('CHANGES.rst')
-          ),
-      keywords = "zope template xml tal",
-      classifiers = [
+      ),
+      keywords="zope template xml tal",
+      classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Intended Audience :: Developers',
@@ -62,29 +67,31 @@ setup(name='zope.tal',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
-      url='http://pypi.python.org/pypi/zope.tal',
+          'Framework :: Zope3',
+      ],
+      url='http://github.com/zopefoundation/zope.tal',
       license='ZPL 2.1',
       packages=find_packages('src'),
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       namespace_packages=['zope'],
-      extras_require = dict(
-          test=['zope.testing',
-                ]),
+      extras_require={
+          'test': TESTS_REQUIRE,
+      },
       test_suite="__main__.alltests", # to support "setup.py test"
-      tests_require=['zope.testrunner'],
-      install_requires=['setuptools',
-                        'zope.i18nmessageid',
-                        'zope.interface',
-                       ],
-      include_package_data = True,
-      zip_safe = False,
-      )
+      tests_require=TESTS_REQUIRE,
+      install_requires=[
+          'setuptools',
+          'zope.i18nmessageid',
+          'zope.interface',
+      ],
+      include_package_data=True,
+      zip_safe=False,
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/tal/tests/__init__.py
+++ b/src/zope/tal/tests/__init__.py
@@ -11,22 +11,3 @@
 # FOR A PARTICULAR PURPOSE
 #
 ##############################################################################
-import sys
-
-if sys.version_info[0] < 3: #pragma NO COVER Python2
-
-    PY2 = True
-    PY3 = False
-
-    def _u(s, encoding='unicode_escape'):
-        return unicode(s, encoding)
-
-else: #pragma NO COVER Python3
-
-    PY2 = False
-    PY3 = True
-
-    def _u(s, encoding=None):
-        if encoding is None:
-            return s
-        return str(s, encoding)

--- a/src/zope/tal/tests/test_talgettext.py
+++ b/src/zope/tal/tests/test_talgettext.py
@@ -16,7 +16,6 @@
 
 from __future__ import print_function
 
-import sys
 import tempfile
 import unittest
 import warnings
@@ -31,7 +30,6 @@ except ImportError:
 from zope.tal.htmltalparser import HTMLTALParser
 from zope.tal.talgettext import POTALInterpreter
 from zope.tal.talgettext import POEngine
-from . import _u
 
 class test_POEngine(unittest.TestCase):
     """Test the PO engine functionality, which simply adds items to a catalog
@@ -47,9 +45,10 @@ class test_POEngine(unittest.TestCase):
             engine.translate(key, 'domain')
 
         for key in test_keys:
-            self.assertTrue(key in engine.catalog['domain'],
-                        "POEngine catalog does not properly store message ids"
-                        )
+            self.assertIn(
+                key, engine.catalog['domain'],
+                "POEngine catalog does not properly store message ids"
+            )
 
     def test_translate_existing(self):
         engine = POEngine()
@@ -75,10 +74,10 @@ class test_POEngine(unittest.TestCase):
         engine.file = 'psc_release_listing.pt'
         # position is position in file.
         engine.translate('foo', 'domain',
-                         default=_u('Read more\u2026'), position=7)
+                         default=u'Read more\u2026', position=7)
         # Adding the same key with the same default is fine.
         engine.translate('foo', 'domain',
-                         default=_u('Read more\u2026'), position=13)
+                         default=u'Read more\u2026', position=13)
         # Adding the same key with a different default is bad and
         # triggers a warning.
         with warnings.catch_warnings(record=True) as log:
@@ -116,9 +115,9 @@ class test_POEngine(unittest.TestCase):
             msgids += list(domain)
         msgids.sort()
         self.assertEqual(msgids,
-            ['A <a href="${DYNAMIC_CONTENT}">link</a>.',
-            'Some ${DYNAMIC_CONTENT} text.'])
+                         ['A <a href="${DYNAMIC_CONTENT}">link</a>.',
+                          'Some ${DYNAMIC_CONTENT} text.'])
 
 
 def test_suite():
-    return unittest.makeSuite(test_POEngine)
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3,coverage
+   py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src []
 deps =
-    zope.testrunner
+    .[test]
 
 [testenv:coverage]
 usedevelop = true
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src
+    coverage report --fail-under=82
 deps =
-    nose
+    {[testenv]deps}
     coverage
-    nosexcover

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ basepython =
     python2.7
 commands =
     coverage run -m zope.testrunner --test-path=src
-    coverage report --fail-under=82
+    coverage report --fail-under=87
 deps =
     {[testenv]deps}
     coverage


### PR DESCRIPTION
- Fix tests under PyPy3
- Whitespace cleanup
- Remove _u compat function.
- Enable coveralls and a coverage environment
  - ~82% covered in one run.

Tweaks to remove some things that aren't run at all from the coverage report get is to around 88% coverage (I wonder if some of those files can be removed).