### PR TITLE
Avoid traceback reference cycle in TALInterpreter.do_onError_tal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.5 (unreleased)
 ================
 
-- Nothing changed yet.
+- Avoid traceback reference cycle in ``TALInterpreter.do_onError_tal``.
 
 
 4.4 (2018-10-05)

--- a/src/zope/tal/talinterpreter.py
+++ b/src/zope/tal/talinterpreter.py
@@ -987,10 +987,15 @@ class TALInterpreter(object):
         # handled.
         except:
             exc = sys.exc_info()[1]
-            self.restoreState(state)
-            engine = self.engine
-            engine.beginScope()
-            error = engine.createErrorInfo(exc, self.position)
+            try:
+                self.restoreState(state)
+                engine = self.engine
+                engine.beginScope()
+                error = engine.createErrorInfo(exc, self.position)
+            finally:
+                # Avoid traceback reference cycle due to the __traceback__
+                # attribute on Python 3.
+                del exc
             engine.setLocal('error', error)
             try:
                 self.interpret(handler)


### PR DESCRIPTION
In Python 3, exceptions have a ``__traceback__`` attribute containing
their associated traceback.  Storing an exception in a local variable of
a frame present in that traceback thus creates a reference cycle.  Avoid
this by explicitly deleting the exception value when we're finished with
it.