### PR TITLE
Fix tests for Python 3.13.6+ compatibility.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix tests for Python 3.13.6+ compatibility.
 
 
 5.1 (2025-02-14)

--- a/src/zope/tal/tests/test_htmltalparser.py
+++ b/src/zope/tal/tests/test_htmltalparser.py
@@ -68,10 +68,11 @@ def rawtext(s):
 class HTMLTALParserTestCases(TestCaseBase):
 
     def test_code_simple_identity(self):
-        self._run_check("""<html a='b' b="c" c=d><title>My Title</html>""", [
-            rawtext('<html a="b" b="c" c="d">'
-                    '<title>My Title</title></html>'),
-        ])
+        self._run_check(
+            """<html a='b' b="c" c=d><title>My Title</title></html>""", [
+                rawtext('<html a="b" b="c" c="d">'
+                        '<title>My Title</title></html>'),
+            ])
 
     def test_code_implied_list_closings(self):
         self._run_check("""<ul><li><p><p><li></ul>""", [


### PR DESCRIPTION
Python 3.13.6 changed the way `<title>` tags are parsed: If there is no end tag, the rest of document is handled as title content.
Source: https://github.com/python/cpython/pull/135310

This change has also been backported to Python 3.12 but is not yet released.

Example of a breaking test: https://github.com/zopefoundation/groktoolkit/actions/runs/16882111176/job/47820322945?pr=102 (Sorry I was not able to reproduce it here in the repository but I also saw it locally on 3.13.6) – The difference is that groktoolkit already uses uv (which already has 3.13.6) and `zope.tal` still relies on the Python versions provided by GitHub Actions (which does not yet have it.)
