### PR TITLE
tests: resolve symlinks for path normalization

### DIFF
--- a/src/zope/tal/driver.py
+++ b/src/zope/tal/driver.py
@@ -160,12 +160,12 @@ def compilefile(file, mode=None):
         else:
             mode = "xml"
     # make sure we can find the file
-    prefix = os.path.dirname(os.path.abspath(__file__)) + os.path.sep
+    prefix = os.path.dirname(os.path.realpath(__file__)) + os.path.sep
     if (not os.path.exists(file)
             and os.path.exists(os.path.join(prefix, file))):
         file = os.path.join(prefix, file)
     # normalize filenames for test output
-    filename = os.path.abspath(file)
+    filename = os.path.realpath(file)
     if filename.startswith(prefix):
         filename = filename[len(prefix):]
     filename = filename.replace(os.sep, '/')  # test files expect slashes


### PR DESCRIPTION
`tests/input/test_sa4.html` includes relative path to
```
<p metal:use-macro="tests/input/test_sa3.html/macro1">
```

which is then normalized with `os.path.abspath`
(i.e. `normpath(join(os.getcwd(), path))`, this is the resolved path) and removing a prefix (see `zope.tal.driver.compilefile` for details).

It's expected to be normalized to `tests/input/test_sa3.html` but actual value differs for venv-based envs, for example:
`/usr/src/RPM/BUILD/python3-module-zope.tal-5.1.1/.run_venv/lib/python3/site-packages/zope/tal/tests/input/test_sa3.html`

This happens because in stdlib's `venv` the `lib64` directory is a symlink to `lib`, while in `virtualenv` (used by upstream) `lib64` is a regular directory.

Closes #25 